### PR TITLE
avoid checking empty string headers

### DIFF
--- a/src/falcon_cors/__init__.py
+++ b/src/falcon_cors/__init__.py
@@ -25,7 +25,7 @@ class CORS(object):
         logger(:py:meth:`logging.Logger`, optional):
             Specifies the logger to use.  A basic logger and StreamHandler
             will be configure for you if none is provided.
-   
+
         allow_all_origins(bool, optional): Specifies whether CORS
             should allow requests from all origins.  Default is ``False``.
 
@@ -426,7 +426,7 @@ class CORS(object):
         if raw_header is None:
             return []
         else:
-            return [requested_header.strip() for requested_header in raw_header.split(',')]
+            return filter(None, [requested_header.strip() for requested_header in raw_header.split(',')])
 
     def _get_requested_method(self, req):
         return req.get_header('access-control-request-method')


### PR DESCRIPTION
Chrome apparently sends empty Access-Control-Request-Headers sometimes
Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=633729

This results in checking the empty string against a list of allowed headers, which doesn't make much sense. Filtering the requested_headers list to remove empty strings should solve this.