### PR TITLE
Convert requested headers to lowercase before validation

### DIFF
--- a/src/falcon_cors/__init__.py
+++ b/src/falcon_cors/__init__.py
@@ -344,7 +344,7 @@ class CORS(object):
 
         approved_headers = []
         for header in requested_headers:
-            if header in self._cors_config['allow_headers_list']:
+            if header.lower() in self._cors_config['allow_headers_list']:
                 approved_headers.append(header)
             elif self._cors_config.get('allow_headers_regex'):
                 if self._cors_config['allow_headers_regex'].match(header):

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -251,6 +251,19 @@ class TestCors(testing.TestBase):
         )
         cors._set_allowed_headers.assert_called_once_with(fake_resp, ['test_header'])
 
+    def test_process_allow_headers_list_camelcase(self):
+        fake_req = mock.MagicMock()
+        fake_resp = mock.MagicMock()
+        cors = CORS(allow_headers_list=['Content-Type'])
+        cors._set_allowed_headers = mock.Mock()
+        self.assertEqual(
+            cors._process_allow_headers(fake_req, fake_resp, ['Content-Type']),
+            True
+        )
+        cors._set_allowed_headers.assert_called_once_with(
+            fake_resp, ['Content-Type']
+        )
+
     def test_process_allow_headers_regex(self):
         fake_req = mock.MagicMock()
         fake_resp = mock.MagicMock()


### PR DESCRIPTION
It looks like Edge browser sends all headers in camel case (or in the same form as client sends them to the API, I didn't test this option). When client sends ```Content-Type``` header it works differently for Edge and other browsers. Edge sends ```Content-Type```, other browsers sends ```content-type```. All headers from ```allow_headers_list``` are changed to lowercase so if Edge sends ```Content-Type``` then ```_process_allow_headers``` method returns False. In my case I can't use API on Edge (it works on IE).

The idea is to change header to lowercase only to check if it exists in ```self._cors_config['allow_headers_list']``` and return not modified header.