### PR TITLE
Adding process_response to middleware

### DIFF
--- a/src/falcon_cors/middleware.py
+++ b/src/falcon_cors/middleware.py
@@ -15,3 +15,10 @@ class CORSMiddleware:
             return
         cors = getattr(resource, 'cors', self.cors)
         cors.process(req, resp, resource)
+
+    
+    def process_response(self, req, resp, resource, req_succeeded):
+        if req_succeeded:
+            return
+        cors = getattr(resource, 'cors', self.cors)
+        cors.process(req, resp, resource)


### PR DESCRIPTION
Adding process_response to middleware to manage CORS info if an exception is raised. In my case, I'm using an auth middleware that raises 403. In this situation, there is no CORS info available in response. Falcon 1.2 adds [independent_middleware](http://falcon.readthedocs.io/en/stable/api/api.html#falcon.API) for executing response middleware independently of request middleware.