### PR TITLE
Include license file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 dist: trusty
 install:
+- python -m pip install --upgrade pip
 - pip install tox
 script:
 - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 dist: trusty
+language: python
 install:
-- python -m pip install --upgrade pip
 - pip install tox
 script:
 - tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include version
+include LICENSE


### PR DESCRIPTION
Hi @lwcolton! I am attempting to add falcon-cors to conda-forge so we can consume it using the conda package manager. They require that the LICENSE file be included in the distribution. Might you be able to cut a 1.1.8 with this PR patch?