### PR TITLE
Include the license in the package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     author_email = 'lwcolton@gmail.com',
     url = 'https://github.com/lwcolton/falcon-cors',
     download_url = 'https://github.com/lwcolton/falcon-cors/archive/master.zip',
+    license = 'Apache 2.0',
     keywords = ['falcon', 'cors', 'http'],
     classifiers = []
 )


### PR DESCRIPTION
This makes the license visible in `pip show falcon-cors`, amongst other tools that make use of the package metadata.